### PR TITLE
Change - Add summary_group parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Instance is to be `present` (default) or `absent`.  Alternatively, a Boolean val
 ##### `rsync_options`
 An array of general options to be passed to rsync.  Note that **ORDER CAN BE IMPORTANT**, as some options may override some or all of others.
 
+##### `summary_group`
+A string which defines the summary group title used in mirrmaid reports.  The default value is set to the resource's *namevar*.
+
 ##### `summary_history_count`
 Keep this many historical copies of operational summaries on disk before they are rotated out of existence.  A minimum value of one is silently enforced.  The default is that from the package.
 

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -18,6 +18,7 @@ define mirrmaid::mirror (
         Mirrmaid::Branches              $branches,
         Ddolib::File::Ensure            $ensure='present',
         String[1]                       $config_filename=$title,
+        String[1]                       $summary_group=$title,
         Optional[Mirrmaid::Defaults]    $defaults={},
         Optional[Array[String[1]]]      $rsync_options=$::mirrmaid::rsync_options,
         Optional[Integer[0]]            $summary_history_count=undef,

--- a/templates/mirror.erb
+++ b/templates/mirror.erb
@@ -12,7 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 [MIRRMAID]
 
-summary_group: <%= @name %>
+summary_group: <%= @summary_group %>
 <% if @summary_history_count -%>
 summary_history_count: <%= @summary_history_count %>
 <% end -%>


### PR DESCRIPTION
This parameter allows customization of the summary_group field in the mirrmaid configuration file.  Default value is set to the resource name.